### PR TITLE
Dont download the file when we only need meta data

### DIFF
--- a/src/AzureAdapter.php
+++ b/src/AzureAdapter.php
@@ -131,7 +131,7 @@ class AzureAdapter implements AdapterInterface
     public function has($path)
     {
         try {
-            $this->client->getBlob($this->container, $path);
+            $this->client->getBlobMetadata($this->container, $path);
         } catch (ServiceException $e) {
             if ($e->getCode() !== 404) {
                 throw $e;

--- a/src/AzureAdapter.php
+++ b/src/AzureAdapter.php
@@ -192,8 +192,8 @@ class AzureAdapter implements AdapterInterface
      */
     public function getMetadata($path)
     {
-        /** @var GetBlobResult $result */
-        $result = $this->client->getBlob($this->container, $path);
+        /** @var GetBlobPropertiesResult $result */
+        $result = $this->client->getBlobProperties($this->container, $path);
 
         return $this->normalizeBlobProperties($path, $result->getProperties());
     }

--- a/tests/AzureTests.php
+++ b/tests/AzureTests.php
@@ -178,14 +178,14 @@ class AzureTests extends \PHPUnit_Framework_TestCase
 
     public function testHasWhenFileExists()
     {
-        $this->azure->shouldReceive('getBlob')->once()->andReturn(true);
+        $this->azure->shouldReceive('getBlobMetadata')->once()->andReturn(true);
 
         $this->assertTrue($this->adapter->has('foo.txt'));
     }
 
     public function testHasWhenFileDoesNotExist()
     {
-        $this->azure->shouldReceive('getBlob')->andThrow(new ServiceException(404));
+        $this->azure->shouldReceive('getBlobMetadata')->andThrow(new ServiceException(404));
 
         $this->assertFalse($this->adapter->has('foo.txt'));
     }
@@ -195,7 +195,7 @@ class AzureTests extends \PHPUnit_Framework_TestCase
      */
     public function testHasWhenError()
     {
-        $this->azure->shouldReceive('getBlob')->andThrow(new ServiceException(500));
+        $this->azure->shouldReceive('getBlobMetadata')->andThrow(new ServiceException(500));
 
         $this->adapter->has('foo.txt');
     }

--- a/tests/AzureTests.php
+++ b/tests/AzureTests.php
@@ -159,7 +159,7 @@ class AzureTests extends \PHPUnit_Framework_TestCase
     {
         $resultBlob = $this->getReadBlobResult('Tue, 02 Dec 2014 08:09:01 +0000', 'foo bar');
 
-        $this->azure->shouldReceive('getBlob')->andReturn($resultBlob);
+        $this->azure->shouldReceive('getBlobProperties')->andReturn($resultBlob);
 
         $expectedResult = [
             'path'      => 'bar/foo.txt',


### PR DESCRIPTION
Currently when either checking if a file exists or when getting meta data for a file the entire file is downloaded while just the meta data is needed.