### PR TITLE
providing a way to retrive a url for public resource via getUrl

### DIFF
--- a/src/AzureAdapter.php
+++ b/src/AzureAdapter.php
@@ -398,4 +398,21 @@ class AzureAdapter extends AbstractAdapter
 
         return $options;
     }
+
+    /**
+     * Return a url link to the object to download or view
+     *
+     * @param String $path
+     *
+     * @return string
+     */
+    public function getUrl($path){
+
+        $path = $this->applyPathPrefix($path);
+
+        $path = $this->client->getUri().$this->container.'/'.$path;
+
+        return $path;
+
+    }
 }


### PR DESCRIPTION
As you can see in **laravel file system** provider  it throws an exception This driver does not support retrieving URLs.

https://github.com/laravel/framework/blob/5.3/src/Illuminate/Filesystem/FilesystemAdapter.php#L301.

but Actually Azure provide retrieving urls .

i did implemented a getUrl method to provide a way to create a path url to the endpoint provided 


i also recommend adding an `accessibleInterface`  that force the implementer to provide a way to `getUrl`.

that all adapter that has a publicly accessible way to provide url should implement.

  