### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "microsoft/azure-storage": "~0.10.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0",
+        "phpunit/phpunit": "~4.8.36",
         "mockery/mockery": "~0.9"
     },
     "autoload": {

--- a/tests/AzureTests.php
+++ b/tests/AzureTests.php
@@ -9,8 +9,9 @@ use MicrosoftAzure\Storage\Blob\Models\CreateBlobOptions;
 use MicrosoftAzure\Storage\Blob\Models\GetBlobResult;
 use MicrosoftAzure\Storage\Common\Internal\Resources;
 use MicrosoftAzure\Storage\Common\ServiceException;
+use PHPUnit\Framework\TestCase;
 
-class AzureTests extends \PHPUnit_Framework_TestCase
+class AzureTests extends TestCase
 {
     const CONTAINER_NAME = 'test-container';
 


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`~4.8.36`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md), that support this namespace.