### PR TITLE
Updated the package to work with the newest azure-storage-blob library.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
 
 install:

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
+        "php": ">=5.6.0",
         "league/flysystem": "~1.0",
         "microsoft/azure-storage-blob": "~1.0.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": ">=5.5.0",
         "league/flysystem": "~1.0",
-        "microsoft/azure-storage": "~0.10.1"
+        "microsoft/azure-storage-blob": "~1.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8.36",

--- a/src/AzureAdapter.php
+++ b/src/AzureAdapter.php
@@ -10,10 +10,10 @@ use MicrosoftAzure\Storage\Blob\Internal\IBlob;
 use MicrosoftAzure\Storage\Blob\Models\BlobPrefix;
 use MicrosoftAzure\Storage\Blob\Models\BlobProperties;
 use MicrosoftAzure\Storage\Blob\Models\CopyBlobResult;
-use MicrosoftAzure\Storage\Blob\Models\CreateBlobOptions;
+use MicrosoftAzure\Storage\Blob\Models\CreateBlockBlobOptions;
 use MicrosoftAzure\Storage\Blob\Models\ListBlobsOptions;
 use MicrosoftAzure\Storage\Blob\Models\ListBlobsResult;
-use MicrosoftAzure\Storage\Common\ServiceException;
+use MicrosoftAzure\Storage\Common\Exceptions\ServiceException;
 
 class AzureAdapter extends AbstractAdapter
 {
@@ -378,11 +378,11 @@ class AzureAdapter extends AbstractAdapter
      *
      * @param Config $config
      *
-     * @return CreateBlobOptions
+     * @return CreateBlockBlobOptions
      */
     protected function getOptionsFromConfig(Config $config)
     {
-        $options = new CreateBlobOptions();
+        $options = new CreateBlockBlobOptions();
 
         foreach (static::$metaOptions as $option) {
             if ( ! $config->has($option)) {


### PR DESCRIPTION
Probably it won't be merged because I noticed that @frankdejonge is working on support of **azure-storage-blob** in a separate repository.

However, before the new library is ready, this update might be useful for some users who still have the old package but want to use **azure-storage-blob** instead of **azure-storage** which was abandoned.